### PR TITLE
allow attaching required permissions to existing role

### DIFF
--- a/iam.tf
+++ b/iam.tf
@@ -17,18 +17,18 @@ module "iam_role" {
         data.aws_route53_zone.targets.*.zone_id
       )
     },
-    {
-      resources = ["*"]
-      effect    = "Allow"
-      actions   = ["route53:ListHostedZones"]
-    }
   ]
+}
+
+locals {
+  role_parts = split("/", var.iam_role_arn)
+  role_name  = var.iam_role_arn == "" ? "" : slice(local.role_parts, length(local.role_parts) - 1, length(local.role_parts))
 }
 
 resource "aws_iam_role_policy" "zone_access" {
   count = var.iam_attach_policy ? 1 : 0
-  name  = module.iam_role.role_id
-  role  = module.iam_role.role_id
+  name  = "external-dns-update-records"
+  role  = local.role_name
   policy = <<-EOF
   {
     "Version": "2012-10-17",

--- a/iam.tf
+++ b/iam.tf
@@ -29,8 +29,8 @@ data "aws_iam_policy_document" "zone_access" {
   count = var.iam_attach_policy ? 1 : 0
 
   statement {
-    effect    = "Allow"
-    actions   = ["route53:ChangeResourceRecordSets", "route53:ListResourceRecordSets"]
+    effect  = "Allow"
+    actions = ["route53:ChangeResourceRecordSets", "route53:ListResourceRecordSets"]
     resources = formatlist(
       "arn:aws:route53:::hostedzone/%s",
       data.aws_route53_zone.targets.*.zone_id

--- a/iam.tf
+++ b/iam.tf
@@ -22,7 +22,7 @@ module "iam_role" {
 
 locals {
   role_parts = split("/", var.iam_role_arn)
-  role_name  = var.iam_role_arn == "" ? "" : slice(local.role_parts, length(local.role_parts) - 1, length(local.role_parts))
+  role_name  = var.iam_role_arn == "" ? "" : join("", slice(local.role_parts, length(local.role_parts) - 1, length(local.role_parts)))
 }
 
 data "aws_iam_policy_document" "zone_access" {

--- a/iam.tf
+++ b/iam.tf
@@ -24,3 +24,27 @@ module "iam_role" {
     }
   ]
 }
+
+resource "aws_iam_role_policy" "zone_access" {
+  count = var.iam_attach_policy ? 1 : 0
+  name  = module.iam_role.role_id
+  role  = module.iam_role.role_id
+  policy = <<-EOF
+  {
+    "Version": "2012-10-17",
+    "Statement": [
+      {
+        "Action": [
+          "route53:ChangeResourceRecordSets",
+          "route53:ListResourceRecordSets"
+        ],
+        "Effect": "Allow",
+        "Resource": ${formatlist(
+  "arn:aws:route53:::hostedzone/%s",
+  data.aws_route53_zone.targets.*.zone_id
+)}
+      }
+    ]
+  }
+EOF
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -3,5 +3,5 @@ output "iam_role_arn" {
 }
 
 output "iam_role_external_id" {
-  value = local.iam_role_external_id
+  value = var.iam_role_external_id == "-" ? "" : local.iam_role_external_id
 }

--- a/variables.tf
+++ b/variables.tf
@@ -75,6 +75,12 @@ variable "create_iam_role" {
   description = "Creates a new dedicated IAM Role for External-DNS"
 }
 
+variable "iam_attach_policy" {
+  type        = bool
+  default     = false
+  description = "When using an existing Role ARN we can attach the required Policy to grant External DNS Permissions"
+}
+
 variable "iam_role_arn" {
   type        = string
   default     = ""


### PR DESCRIPTION
This also removes the `ListHostedZones` permission. As we set Zone IDs explicitly external-dns does not need to lookup Zones by itself.  