### PR TITLE
external dns requires list hosted zones permissions

### DIFF
--- a/iam.tf
+++ b/iam.tf
@@ -17,6 +17,11 @@ module "iam_role" {
         data.aws_route53_zone.targets.*.zone_id
       )
     },
+    {
+      effect    = "Allow"
+      resources = ["*"]
+      actions   = ["route53:ListHostedZones"]
+    },
   ]
 }
 
@@ -29,12 +34,20 @@ data "aws_iam_policy_document" "zone_access" {
   count = var.iam_attach_policy ? 1 : 0
 
   statement {
+    sid     = "AllowChangingRecordsInZones"
     effect  = "Allow"
     actions = ["route53:ChangeResourceRecordSets", "route53:ListResourceRecordSets"]
     resources = formatlist(
       "arn:aws:route53:::hostedzone/%s",
       data.aws_route53_zone.targets.*.zone_id
     )
+  }
+
+  statement {
+    sid       = "AllowListingZones"
+    effect    = "Allow"
+    resources = ["*"]
+    actions   = ["route53:ListHostedZones"]
   }
 }
 


### PR DESCRIPTION
https://github.com/kubernetes-sigs/external-dns/blob/3a61439cd116741012026036e166008993d0d0e7/provider/aws/aws.go\#L230
even hosted zone ids are specified external dns does a lookup anyway and required therefore ListHostedZones permissions