### PR TITLE
deploy cluster role when not namespace bound

### DIFF
--- a/defaults.yaml
+++ b/defaults.yaml
@@ -39,6 +39,7 @@ aws:
 rbac:
   create: true
   pspEnabled: ${psp_enabled}
+  clusterRole: ${namespace_scoped ? false : true}
 
 metrics:
   enabled: true


### PR DESCRIPTION
follow up on https://github.com/goci-io/aws-external-cluster-dns/pull/21, https://github.com/goci-io/aws-external-cluster-dns/pull/20