### PR TITLE
filter empty domain names

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -8,8 +8,12 @@ terraform {
   }
 }
 
+locals {
+  domains = compact(var.domains)
+}
+
 data "aws_route53_zone" "targets" {
-  count        = length(var.domains)
-  name         = format("%s.", trim(var.domains[count.index], "."))
+  count        = length(local.domains)
+  name         = format("%s.", trim(local.domains[count.index], "."))
   private_zone = var.is_private_zone
 }


### PR DESCRIPTION
this might be the case when there was an empty state for example
create module -> delete module -> apply module again fails during refresh because it cant find an empty domain which is still referenced in the state itself.

assuming one is using anther module to create the route53 zone and passing in an output to this module. 

```
module "zone" {
  # ...
}

module "this_module" {
  domains = [module.zone.domain_name]
}
```

This will fail on a Refresh on a state which was previously destroyed. This makes it nearly impossible to restore without deleting the old state file (manual action)